### PR TITLE
Make reader thumnail page numbers clearer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4605,6 +4605,7 @@
 			readerProgress.style.float = rd.rtl ? 'right' : 'left';
 
 			[rd.currentPage, readerPage.innerText] = getPageFromSpread(currentSpreadIndex);
+			readerPage.innerText = readerPage.innerText.replace(" ", " | ");
 
 			readerPage.style.left = rd.rtl
 				? `min(max(0px, calc(${100 - progressPercent}% - ${readerPage.clientWidth * 0.5}px)), calc(100% - ${readerPage.clientWidth}px))`


### PR DESCRIPTION
Currently, page numbers in the reader thumbnail are displayed as "2 3", which I have a couple times mistaken for "23."  This updates the display to show the numbers as "2 | 3" for more clarity.