### PR TITLE
Correct "pag" typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -3895,7 +3895,7 @@
 						&series_id=${book.seriesId}
 						&book_id=${book.id}
 						&dir=${readingDirection}
-						&pag=${(book.readProgress ? book.readProgress.page : 1)}`);
+						&page=${(book.readProgress ? book.readProgress.page : 1)}`);
 			});
 
 			item.append(booksItem);
@@ -4313,11 +4313,11 @@
 						&series_id=${book.seriesId}
 						&book_id=${book.id}
 						&dir=${readingDirection}
-						&pag=${force ? 1 : (book.readProgress ? book.readProgress.page : 1)}`);
+						&page=${force ? 1 : (book.readProgress ? book.readProgress.page : 1)}`);
 		}
 
 		// Function that setups the reader for a specific book, this is not run directly
-		function openBookReader(libraryId, seriesId, bookId, dir, pag) {
+		function openBookReader(libraryId, seriesId, bookId, dir, page) {
 			//TODO aggiungere funzione per pulire l'array del preload e quello delle pic
 			Object.entries(dashboardElements).forEach(([name, item]) => {
 				item.homeStrip.innerHTML = '';
@@ -4333,7 +4333,7 @@
 			rd.webtoonScrollRatio = 0;
 			rd.rtl = (dir == 'RIGHT_TO_LEFT');
 
-			rd.currentPage = pag;
+			rd.currentPage = page;
 
 			rd.spreadsArray = [];
 
@@ -5521,7 +5521,7 @@
 			&series_id=${rd.seriesId}
 			&book_id=${rd.bookId}
 			&dir=${rd.direction}
-			&pag=${rd.currentPage}`;
+			&page=${rd.currentPage}`;
 
 			if (!rd.incognito) {
 				callAPI(null, `/api/v1/books/${rd.bookId}/read-progress`, 'PATCH', JSON.stringify({ page: rd.currentPage }), false)
@@ -6296,7 +6296,7 @@
 					await performSearch(params.get('search_string'));
 					break;
 				case 'bookread':
-					await openBookReader(params.get('library_id'), params.get('series_id'), params.get('book_id'), params.get('dir'), params.get('pag'));
+					await openBookReader(params.get('library_id'), params.get('series_id'), params.get('book_id'), params.get('dir'), params.get('page'));
 					break;
 				case 'offlinebooks':
 					searchInput.value = '';


### PR DESCRIPTION
"Page" was spelled "pag" in a few places, which ended up in the url of the reading view.  See #62 .  