### PR TITLE
fix(reader): request page images explicitly for Komga PDF pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1109,6 +1109,7 @@
 				method: method,
 				...((isWeb && !webPWD) && { credentials: 'include' }),
 				headers: {
+					'Accept': 'image/*',
 					'X-Requested-With': 'XMLHttpRequest',
 					'skip_zrok_interstitial': '1',
 					...basicHeaders
@@ -2904,6 +2905,7 @@
 				'image/webp': '.webp',
 				'image/gif': '.gif',
 			};
+			const mediaRequestData = await buildRequestMedia('GET', null);
 
 			const baseDir = 'offline-books';
 			const bookFolder = `${baseDir}/${bookId}`;
@@ -3004,7 +3006,7 @@
 
 					if (!pageExists) {
 						const pageUrl = `${baseUrl}/api/v1/books/${bookId}/pages/${page.number}`;
-						const pageRes = await fetch(pageUrl, requestData);
+						const pageRes = await fetch(pageUrl, mediaRequestData);
 						if (!pageRes.ok) throw new Error(`Page ${page.number} failed: ${pageRes.status}`);
 						const pageBuffer = await pageRes.arrayBuffer();
 						await Capacitor.Plugins.Filesystem.writeFile({
@@ -3027,7 +3029,7 @@
 
 					if (!thumbExists) {
 						const thumbPageUrl = `${baseUrl}/api/v1/books/${bookId}/pages/${page.number}/thumbnail`;
-						const thumbRes = await fetch(thumbPageUrl, requestData);
+						const thumbRes = await fetch(thumbPageUrl, mediaRequestData);
 						if (!thumbRes.ok) throw new Error(`Thumb ${page.number} failed: ${thumbRes.status}`);
 						const thumbPageBuffer = await thumbRes.arrayBuffer();
 						await Capacitor.Plugins.Filesystem.writeFile({

--- a/package-main.js
+++ b/package-main.js
@@ -137,6 +137,13 @@ ipcMain.handle('read-file', async (_, filePath) => {
 
 ipcMain.handle('download-and-store-book', async (_, { bookId, bookTitle, baseUrl, requestData }) => {
 	const win = BrowserWindow.getFocusedWindow(); // or keep a ref to your main window
+	const mediaRequestData = {
+		...requestData,
+		headers: {
+			...(requestData?.headers || {}),
+			Accept: 'image/*',
+		},
+	};
 
 	const baseDir = path.join(app.getPath('userData'), 'offline-books');
 	await fs.mkdir(baseDir, { recursive: true });
@@ -213,7 +220,7 @@ ipcMain.handle('download-and-store-book', async (_, { bookId, bookTitle, baseUrl
 			if (!pageExists) {
 				const pageUrl = `${baseUrl}/api/v1/books/${bookId}/pages/${page.number}`;
 				console.log(`Downloading page ${page.number}...`);
-				const res = await fetch(pageUrl, requestData);
+				const res = await fetch(pageUrl, mediaRequestData);
 				if (!res.ok) throw new Error(`Failed to fetch page ${page.number}: ${res.status}`);
 				const buffer = Buffer.from(await res.arrayBuffer());
 				await fs.writeFile(pageFile, buffer);
@@ -230,7 +237,7 @@ ipcMain.handle('download-and-store-book', async (_, { bookId, bookTitle, baseUrl
 			if (!thumbExists) {
 				const thumbUrl = `${baseUrl}/api/v1/books/${bookId}/pages/${page.number}/thumbnail`;
 				console.log(`Downloading thumb ${page.number}...`);
-				const res2 = await fetch(thumbUrl, requestData);
+				const res2 = await fetch(thumbUrl, mediaRequestData);
 				if (!res2.ok) throw new Error(`Failed to fetch thumbnail ${page.number}: ${res.status}`);
 				const buffer2 = Buffer.from(await res2.arrayBuffer());
 				await fs.writeFile(thumbFile, buffer2);
@@ -260,4 +267,3 @@ ipcMain.handle('download-and-store-book', async (_, { bookId, bookTitle, baseUrl
 		return { ok: false, error: err.message };
 	}
 });
-


### PR DESCRIPTION
## Summary

Explicitly request image content for Komga page media requests by sending `Accept: image/*`.

## Problem

MangaBox renders reading pages with `<img>` elements. For PDF books served by Komga, the page endpoint can return `application/pdf` unless the client explicitly requests an image response.

This leads to a situation where:
- login works
- library browsing works
- thumbnails load
- progress updates work

but the actual reading page stays blank.

This appears related to the behavior reported in #66.

## Root cause

On my setup, the same Komga page endpoint returned:
- `application/pdf` by default
- `image/jpeg` when `Accept: image/*` was sent

Since MangaBox uses `<img>` for reader pages, the PDF response cannot be rendered correctly.

## Changes

- add `Accept: image/*` to reader media requests
- apply the same fix to offline page downloads on Electron and Capacitor/mobile

## Validation

- reproduced blank PDF pages against Komga
- confirmed the endpoint returned `application/pdf` by default for PDF books
- confirmed the same endpoint returned `image/jpeg` with `Accept: image/*`
- verified `package-main.js` syntax with `node --check`
